### PR TITLE
Use forecasts for controllers

### DIFF
--- a/02 - config/example_single_market/config_agents.yaml
+++ b/02 - config/example_single_market/config_agents.yaml
@@ -955,24 +955,26 @@ sfh:
 
       fcast:
         local:
-          method: naive                            # forecasting method for local market prices
-                                                  # options:
-                                                  #   - flat:  no meaningful forecasting, flat price assumed
-                                                  #   - naive: expected price same as previous day (initialized flat)
-                                                  # note: does not apply when simulation ex-post markets
+          method: naive                         # forecasting method for local market prices
+                                                # options:
+                                                #   - flat:  no meaningful forecasting, flat price assumed
+                                                #   - naive: expected price same as previous day (initialized flat)
+                                                # note: does not apply when simulation ex-post markets
 
-          naive:
-            offset: 1
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
 
         wholesale:
-          method: naive                        # forecasting method for wholesale market prices
+          method: naive                         # forecasting method for wholesale market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
                                                 #   - perfect: perfect foresight of market price
 
-          naive:
-            offset: 1
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
 
         retailer:
           energy: ['naive', 'naive']            # forecasting method for retailer market prices and quantities

--- a/02 - config/templates/config_agents.yaml
+++ b/02 - config/templates/config_agents.yaml
@@ -892,18 +892,27 @@ sfh:
                                                 # note: each agent selects a random value off this list
 
       fcast:
-        local: naive                            # forecasting method for local market prices
+        local:
+          method: naive                         # forecasting method for local market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
-                                                #   - perfect: perfect foresight of market price
                                                 # note: does not apply when simulation ex-post markets
 
-        wholesale: naive                        # forecasting method for wholesale market prices
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
+
+        wholesale:
+          method: naive                         # forecasting method for wholesale market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
                                                 #   - perfect: perfect foresight of market price
+
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
 
     fcasts:                                     # forecasting settings for all forecasts
         retraining_period: 86_400               # period after which the forecast model is retrained
@@ -1906,18 +1915,27 @@ mfh:
                                                 # note: each agent selects a random value off this list
 
       fcast:
-        local: naive                            # forecasting method for local market prices
+        local:
+          method: naive                         # forecasting method for local market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
-                                                #   - perfect: perfect foresight of market price
                                                 # note: does not apply when simulation ex-post markets
 
-        wholesale: naive                        # forecasting method for wholesale market prices
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
+
+        wholesale:
+          method: naive                         # forecasting method for wholesale market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
                                                 #   - perfect: perfect foresight of market price
+
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
 
     fcasts:                                     # forecasting settings for all forecasts
         retraining_period: 86_400               # period after which the forecast model is retrained
@@ -2530,18 +2548,27 @@ ctsp:
                                                 # note: each agent selects a random value off this list
 
       fcast:
-        local: naive                            # forecasting method for local market prices
+        local:
+          method: naive                         # forecasting method for local market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
-                                                #   - perfect: perfect foresight of market price
                                                 # note: does not apply when simulation ex-post markets
 
-        wholesale: naive                        # forecasting method for wholesale market prices
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
+
+        wholesale:
+          method: naive                         # forecasting method for wholesale market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
                                                 #   - perfect: perfect foresight of market price
+
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
 
     fcasts:                                     # forecasting settings for all forecasts
         retraining_period: 86_400               # period after which the forecast model is retrained
@@ -3161,18 +3188,27 @@ industry:
                                                 # note: each agent selects a random value off this list
 
       fcast:
-        local: naive                            # forecasting method for local market prices
+        local:
+          method: naive                         # forecasting method for local market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
-                                                #   - perfect: perfect foresight of market price
                                                 # note: does not apply when simulation ex-post markets
 
-        wholesale: naive                        # forecasting method for wholesale market prices
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
+
+        wholesale:
+          method: naive                         # forecasting method for wholesale market prices
                                                 # options:
                                                 #   - flat:  no meaningful forecasting, flat price assumed
                                                 #   - naive: expected price same as previous day (initialized flat)
                                                 #   - perfect: perfect foresight of market price
+
+          naive:                                # naive forecasting method parameters
+            offset: 1                           # offset in days to the current day
+                                                # unit: days
 
     fcasts:                                     # forecasting settings for all forecasts
         retraining_period: 86_400               # period after which the forecast model is retrained
@@ -3301,7 +3337,7 @@ producer:
       
     ################################ battery ####################################
     battery: 
-      num: [1]                                  # number of fixed generators
+      num: [1]                                  # number of batteries
                                                 # note: value is randomly chosen from list
 
       sizing:                                   # sizing of battery system
@@ -3362,18 +3398,27 @@ producer:
                                                   # note: each agent selects a random value off this list
 
         fcast:
-          local: naive                            # forecasting method for local market prices
+          local:
+            method: naive                         # forecasting method for local market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
-                                                  #   - perfect: perfect foresight of market price
                                                   # note: does not apply when simulation ex-post markets
 
-          wholesale: naive                        # forecasting method for wholesale market prices
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
+
+          wholesale:
+            method: naive                         # forecasting method for wholesale market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
                                                   #   - perfect: perfect foresight of market price
+
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
 
       fcasts:                                     # forecasting settings for all forecasts
           retraining_period: 86_400               # period after which the forecast model is retrained
@@ -3540,18 +3585,27 @@ producer:
                                                   # note: each agent selects a random value off this list
 
         fcast:
-          local: naive                            # forecasting method for local market prices
+          local:
+            method: naive                         # forecasting method for local market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
-                                                  #   - perfect: perfect foresight of market price
                                                   # note: does not apply when simulation ex-post markets
 
-          wholesale: naive                        # forecasting method for wholesale market prices
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
+
+          wholesale:
+            method: naive                         # forecasting method for wholesale market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
                                                   #   - perfect: perfect foresight of market price
+
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
 
       fcasts:                                     # forecasting settings for all forecasts
           retraining_period: 86_400               # period after which the forecast model is retrained
@@ -3714,18 +3768,27 @@ producer:
                                                   # note: each agent selects a random value off this list
 
         fcast:
-          local: naive                            # forecasting method for local market prices
+          local:
+            method: naive                         # forecasting method for local market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
-                                                  #   - perfect: perfect foresight of market price
                                                   # note: does not apply when simulation ex-post markets
 
-          wholesale: naive                        # forecasting method for wholesale market prices
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
+
+          wholesale:
+            method: naive                         # forecasting method for wholesale market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
                                                   #   - perfect: perfect foresight of market price
+
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
 
       fcasts:                                     # forecasting settings for all forecasts
           retraining_period: 86_400               # period after which the forecast model is retrained
@@ -3824,18 +3887,27 @@ storage:
                                                   # note: each agent selects a random value off this list
 
         fcast:
-          local: naive                            # forecasting method for local market prices
+          local:
+            method: naive                         # forecasting method for local market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
-                                                  #   - perfect: perfect foresight of market price
                                                   # note: does not apply when simulation ex-post markets
 
-          wholesale: naive                        # forecasting method for wholesale market prices
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
+
+          wholesale:
+            method: naive                         # forecasting method for wholesale market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
                                                   #   - perfect: perfect foresight of market price
+
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
 
       fcasts:                                     # forecasting settings for all forecasts
           retraining_period: 86_400               # period after which the forecast model is retrained
@@ -3928,18 +4000,27 @@ storage:
                                                   # note: each agent selects a random value off this list
 
         fcast:
-          local: naive                            # forecasting method for local market prices
+          local:
+            method: naive                         # forecasting method for local market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
-                                                  #   - perfect: perfect foresight of market price
                                                   # note: does not apply when simulation ex-post markets
 
-          wholesale: naive                        # forecasting method for wholesale market prices
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
+
+          wholesale:
+            method: naive                         # forecasting method for wholesale market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
                                                   #   - perfect: perfect foresight of market price
+
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
 
       fcasts:                                     # forecasting settings for all forecasts
           retraining_period: 86_400               # period after which the forecast model is retrained
@@ -4032,18 +4113,27 @@ storage:
                                                   # note: each agent selects a random value off this list
 
         fcast:
-          local: naive                            # forecasting method for local market prices
+          local:
+            method: naive                         # forecasting method for local market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
-                                                  #   - perfect: perfect foresight of market price
                                                   # note: does not apply when simulation ex-post markets
 
-          wholesale: naive                        # forecasting method for wholesale market prices
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
+
+          wholesale:
+            method: naive                         # forecasting method for wholesale market prices
                                                   # options:
                                                   #   - flat:  no meaningful forecasting, flat price assumed
                                                   #   - naive: expected price same as previous day (initialized flat)
                                                   #   - perfect: perfect foresight of market price
+
+            naive:                                # naive forecasting method parameters
+              offset: 1                           # offset in days to the current day
+                                                  # unit: days
 
       fcasts:                                     # forecasting settings for all forecasts
           retraining_period: 86_400               # period after which the forecast model is retrained

--- a/hamlet/executor/agents/agent.py
+++ b/hamlet/executor/agents/agent.py
@@ -146,10 +146,8 @@ class AgentBase:
             strategy = Trading(strategy=market_info['strategy'], timetable=self.timetable,
                                market=market, market_data=self.market, agent=self.agent).create_instance()
 
-
             # Create bids and offers
             self.agent = strategy.create_bids_offers()
 
         return self.agent
-
 

--- a/hamlet/executor/utilities/controller/mpc/lincomps.py
+++ b/hamlet/executor/utilities/controller/mpc/lincomps.py
@@ -94,16 +94,14 @@ class Market(LinopyComps):
         self.comp_type = None
 
         # Calculate the upper and lower bounds for the market power
-        # TODO: Adjust once there is a forecast for the available energy
         self.upper = [int(round(x / self.dt_hours)) for x in self.fcast[f'energy_quantity_sell']]
         self.lower = [int(round(x / self.dt_hours * -1)) for x in self.fcast[f'energy_quantity_buy']]
 
         # Get market price forecasts
-        # TODO: Adjust once there is a forecast for the market prices
         self.price_sell = pd.Series(self.fcast[f'energy_price_sell'], index=self.timesteps)
         self.price_buy = pd.Series(self.fcast[f'energy_price_buy'], index=self.timesteps)
-        self.grid_sell = pd.Series(self.fcast[f'grid_sell'], index=self.timesteps)
-        self.grid_buy = pd.Series(self.fcast[f'grid_buy'], index=self.timesteps)
+        self.grid_sell = pd.Series(self.fcast[f'grid_local_sell'], index=self.timesteps)
+        self.grid_buy = pd.Series(self.fcast[f'grid_local_buy'], index=self.timesteps)
         self.levies_sell = pd.Series(self.fcast[f'levies_price_sell'], index=self.timesteps)
         self.levies_buy = pd.Series(self.fcast[f'levies_price_buy'], index=self.timesteps)
 
@@ -257,12 +255,9 @@ class SimplePlant(LinopyComps):
         super().__init__(name, **kwargs)
 
         # Get specific object attributes
-        try:
-            self.power = [int(x) for x in list(self.fcast[f'{self.name}_power'].round())]  # TODO: Fix that round is not needed anymore
-        except:
-            self.power = list(self.fcast[f'{self.name}_power'])
+        self.power = list(self.fcast[f'{self.name}_power'])
         self.controllable = self.info['sizing']['controllable']
-        self.lower = [0] * len(self.power) if self.controllable else self.power # TODO
+        self.lower = [0] * len(self.power) if self.controllable else self.power
 
     def define_variables(self, model, **kwargs):
         comp_type = kwargs['comp_type']

--- a/hamlet/executor/utilities/controller/mpc/mpc.py
+++ b/hamlet/executor/utilities/controller/mpc/mpc.py
@@ -16,7 +16,6 @@ from hamlet import constants as c
 from hamlet.executor.utilities.controller.mpc import lincomps
 from hamlet.executor.utilities.controller.base import ControllerBase
 from hamlet.executor.utilities.database.database import Database as db
-import math  # TODO: Take back out again once forecasts exist
 from hamlet import functions as f
 
 
@@ -73,15 +72,7 @@ class Mpc(ControllerBase):
             self.ems = self.account['ems']
             self.plants = self.agent.plants  # Formerly known as components
             self.setpoints = self.agent.setpoints
-            self.forecasts = self.agent.timeseries.collect()  # TODO: Replace with forecasts once they exist
-            # self.forecasts = self.agent.forecasts.collect()
-            # with pl.Config() as cfg:
-            #     cfg.set_tbl_width_chars(200)
-            #     cfg.set_tbl_cols(30)
-            #     print(self.forecasts)
-            # print('Forecast is now implemented. Next step is to replace the dummy data with the actual forecasts. \n'
-            #       'Also probably necessary to convert the retailer data as it is still using fractions')
-            # exit()
+            self.forecasts = self.agent.forecasts.collect()
             self.socs = self.agent.socs.collect()
 
             # Get the timetable
@@ -90,23 +81,23 @@ class Mpc(ControllerBase):
             self.dt = self.timetable.collect()[1, c.TC_TIMESTEP] - self.timetable.collect()[0, c.TC_TIMESTEP]
             # Get the current timestamp
             self.timestamp = self.timetable.collect()[0, c.TC_TIMESTAMP]
-            # Get the next timestamp
-            self.next_timestamp = self.timestamp + self.dt  # TODO: Might not be needed
             # Get the time horizon
             self.horizon = pd.Timedelta(seconds=self.ems['controller']['mpc']['horizon'])
 
             # Reduce the forecast to the horizon length
-            self.forecasts = self.forecasts.filter((self.timestamp < self.forecasts[c.TC_TIMESTAMP])
-                                                   & (self.forecasts[c.TC_TIMESTAMP] < self.timestamp + self.horizon))
+            self.forecasts = self.forecasts.filter((self.timestamp < self.forecasts[c.TC_TIMESTEP])
+                                                   & (self.forecasts[c.TC_TIMESTEP] < self.timestamp + self.horizon))
+
             # Get the timesteps and the number of timesteps in the forecast
             self.timesteps = pd.Index(self.forecasts.select(c.TC_TIMESTAMP).to_pandas(), name='timesteps')
             self.n_steps = pd.Index(range(len(self.timesteps)), name='timesteps')
-            self.timesteps = self.n_steps  # TODO: Take out again
+            # self.timesteps = self.n_steps  # Use this line if the timesteps are not needed and the index is sufficient
             # Reduce the socs to the current timestamp
             self.socs = self.socs.filter(self.socs[c.TC_TIMESTAMP] == self.timestamp)
 
             # Get the market types
-            # TODO: Still needs to be done and then adjusted in the market objects
+            # TODO: Still needs to be done and then adjusted in the market objects (right now the names are simply
+            #  local and wholesale as this will suffice as long as there is only one market)
             # Get the market data
             self.market = kwargs['market']
             # Get the market names and types
@@ -114,26 +105,6 @@ class Mpc(ControllerBase):
             self.market_types = self.timetable.collect().select(c.TC_MARKET).unique().to_series().to_list()
             # Assign each market name to an energy type
             self.markets = {name: c.TRADED_ENERGY[mtype] for name, mtype in zip(self.market_names, self.market_types)}
-
-            # TODO: Take out again once the forecasts are available
-            # Create dummy forecasts for the market and append them to the forecasts
-            dummy = {}
-            dummy['energy_price_sell'] = [(math.cos(x)  + 4) / 100 for x in np.linspace(0, 2 * math.pi, len(self.timesteps))]
-            dummy['energy_price_buy'] = [(2 * math.cos(x) + 6) / 100 for x in np.linspace(0, 2 * math.pi, len(self.timesteps))]
-            dummy['energy_quantity_sell'] = [1e5] * len(self.timesteps)
-            dummy['energy_quantity_buy'] = [1e5] * len(self.timesteps)
-            dummy['grid_sell'] = [0] * len(self.timesteps)
-            dummy['grid_buy'] = [0.04] * len(self.timesteps)
-            dummy['grid_retail_sell'] = [0] * len(self.timesteps)
-            dummy['grid_retail_buy'] = [0.08] * len(self.timesteps)
-            dummy['levies_price_sell'] = [0] * len(self.timesteps)
-            dummy['levies_price_buy'] = [0.18] * len(self.timesteps)
-
-            # Combine the forecasts with the dummy forecasts
-            for col, vals in dummy.items():
-                self.forecasts = self.forecasts.with_columns(pl.Series(name=col, values=vals))
-            # print(self.forecasts)
-            # print(self.forecasts.columns)
 
             # Available plants
             self.available_plants = {
@@ -203,7 +174,7 @@ class Mpc(ControllerBase):
             """"""
 
             # Define variables from the market results and a balancing variable for each energy type
-            for market in self.markets: # TODO: Change once it is clear how the markets are defined
+            for market in self.markets:  # TODO: Change once it is clear how the markets are defined
                 # Create market object
                 self.market_objects[f'{market}'] = lincomps.Market(name=market,
                                                                    forecasts=self.forecasts,
@@ -418,7 +389,7 @@ class Mpc(ControllerBase):
             # Update setpoints
             self.setpoints = self.setpoints.update(adjusted_solution, on=c.TC_TIMESTAMP)
 
-            # with pl.Config(tbl_cols=20, fmt_str_lengths=50):
+            # with pl.Config(tbl_cols=20, fmt_str_lengths=200):
             #     print(self.setpoints)
             # exit()
 

--- a/hamlet/executor/utilities/trading/strategies.py
+++ b/hamlet/executor/utilities/trading/strategies.py
@@ -156,7 +156,6 @@ class TradingBase:
 
 
 class Linear(TradingBase):
-    # TODO: Will probably need to be changed in the future
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Now uses the forecasts for mpc instead of the previously used dummy data. 
