### PR TITLE
Bugfix high balancing

### DIFF
--- a/hamlet/executor/utilities/controller/rtc/lincomps.py
+++ b/hamlet/executor/utilities/controller/rtc/lincomps.py
@@ -105,7 +105,7 @@ class Market(LinopyComps):
 
         # Get specific object attributes
         self.dt = kwargs['delta'].total_seconds()  # time delta in seconds
-        self.market_power = int(round(kwargs['market_result'] / self.dt * c.SECONDS_TO_HOURS))  # market power in W
+        self.market_power = int(round(kwargs['market_result'] * c.HOURS_TO_SECONDS / self.dt))  # from Wh to W
         self.balancing_power = 10000000000  # TODO: This needs to be changed to the max available balancing power
 
         # Get the energy type


### PR DESCRIPTION
Conversion from Wh to W was wrong. That is why it then usually never "bought" enough energy to have a value greater 0 in the rtc. For this reason it tried to use its flexibility options first to "sell" as little energy as possible from its previous target. The issue was just one variable that was wrong.

Solves issue #75 