### PR TITLE
Fix bug controllable for creation of scenarios using grid file

### DIFF
--- a/hamlet/creator/agents/ctsp.py
+++ b/hamlet/creator/agents/ctsp.py
@@ -10,6 +10,7 @@ import pandas as pd
 import numpy as np
 from ruamel.yaml.compat import ordereddict
 import hamlet.constants as c
+import random
 
 
 class Ctsp(AgentBase):
@@ -547,8 +548,8 @@ class Ctsp(AgentBase):
                 self.df[f"{key}/sizing/orientation_{num}"] = 0
                 self.df[f"{key}/sizing/angle_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -656,8 +657,8 @@ class Ctsp(AgentBase):
                 # Assign standard height since they do not matter if no file is specified
                 # self.df[f"{key}/sizing/height_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -752,8 +753,8 @@ class Ctsp(AgentBase):
                                                                        device=f"{key}",
                                                                        input_path=os.path.join(self.input_path, key))
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)

--- a/hamlet/creator/agents/industry.py
+++ b/hamlet/creator/agents/industry.py
@@ -10,6 +10,7 @@ import pandas as pd
 import numpy as np
 from ruamel.yaml.compat import ordereddict
 import hamlet.constants as c
+import random
 
 
 class Industry(AgentBase):
@@ -549,8 +550,8 @@ class Industry(AgentBase):
                 self.df[f"{key}/sizing/orientation_{num}"] = 0
                 self.df[f"{key}/sizing/angle_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -658,8 +659,8 @@ class Industry(AgentBase):
                 # Assign standard height since they do not matter if no file is specified
                 # self.df[f"{key}/sizing/height_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -754,8 +755,8 @@ class Industry(AgentBase):
                                                                        device=f"{key}",
                                                                        input_path=os.path.join(self.input_path, key))
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)

--- a/hamlet/creator/agents/mfh.py
+++ b/hamlet/creator/agents/mfh.py
@@ -11,6 +11,7 @@ import pandas as pd
 import numpy as np
 from ruamel.yaml.compat import ordereddict
 import hamlet.constants as c
+import random
 
 
 class Mfh(AgentBase):
@@ -932,8 +933,8 @@ class Mfh(AgentBase):
                 self.df[f"{key}/sizing/orientation_{num}"] = 0
                 self.df[f"{key}/sizing/angle_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -1052,8 +1053,8 @@ class Mfh(AgentBase):
                 # Assign standard height since they do not matter if no file is specified
                 # self.df[f"{key}/sizing/height_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -1163,8 +1164,8 @@ class Mfh(AgentBase):
                                                                        device=f"{key}",
                                                                        input_path=os.path.join(self.input_path, key))
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
         # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)

--- a/hamlet/creator/agents/sfh.py
+++ b/hamlet/creator/agents/sfh.py
@@ -12,6 +12,7 @@ from ruamel.yaml.compat import ordereddict
 from pprint import pprint
 import hamlet.constants as c
 from typing import Callable
+import random
 
 
 class Sfh(AgentBase):
@@ -720,8 +721,8 @@ class Sfh(AgentBase):
                 self.df[f"{key}/sizing/orientation_{num}"] = 0
                 self.df[f"{key}/sizing/angle_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
             # forecast
         self.df = self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -835,8 +836,8 @@ class Sfh(AgentBase):
                 # Assign standard height since they do not matter if no file is specified
                 # self.df[f"{key}/sizing/height_{num}"] = 0
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
             # forecast
         self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)
@@ -937,8 +938,8 @@ class Sfh(AgentBase):
                                                                        device=f"{key}",
                                                                        input_path=os.path.join(self.input_path, key))
 
-            # Make all plants controllable
-            self.df[f"{key}/sizing/controllable_{num}"] = True
+            # Pick random value from the config file for controllability
+            self.df[f"{key}/sizing/controllable_{num}"] = random.choice(config["sizing"]["controllable"])
 
             # forecast
         self._add_info_simple(keys=[key, "fcast"], config=config["fcast"], df=self.df)


### PR DESCRIPTION
Controllable is now randomly chosen from config

## TL;DR
Controllability of plants was always set to True when creating scenarios from grid file. Now it is randomly chosen from scenario config.

---

## Linked Issues
Closes #85 

## Description
See TLDR

## How to test
Run a scenario that is created from grid file.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My PR is concise and addresses only one bug/feature (otherwise split PR into two)
- [x] My PR has a concise and descriptive title
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code and PR and have added comments in the PR code to help the reviewer.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Additional Notes
Add any other notes or comments here.

[How to make a good PR (Video)](https://www.youtube.com/watch?v=_HedItVFr5M)
