### PR TITLE
Bugfix of meters only recording one energy type per plant

### DIFF
--- a/hamlet/creator/agents/agents.py
+++ b/hamlet/creator/agents/agents.py
@@ -483,10 +483,13 @@ class Agents:
                 plants_ids += [plant_id]
 
                 # Add meter data
-                meters[plant_id] = self.__init_vals(df=meters)  # TODO: Ponder if rows need to be added here
+                energy_types = c.COMP_MAP[plant].keys()
+                for key in energy_types:
+                    col_id = f'{plant_id}_{plant}_{key}'
+                    meters[col_id] = self.__init_vals(df=meters)
 
                 # Add setpoints
-                setpoints[plant_id] = self.__init_vals(df=setpoints)  # TODO: Ponder if rows need to be added here
+                setpoints[plant_id] = self.__init_vals(df=setpoints)
 
                 # Add and process additional plant information
                 plant_dict.update(info)

--- a/hamlet/executor/utilities/controller/rtc/rtc.py
+++ b/hamlet/executor/utilities/controller/rtc/rtc.py
@@ -495,7 +495,7 @@ class Rtc(ControllerBase):
                     meter_now = row_now[col]
 
                     # Update meter value in row new
-                    row_new = row_new.with_columns(pl.lit(meter_now + round(delta_energy)).cast(dtype).alias(key))
+                    row_new = row_new.with_columns(pl.lit(meter_now + round(delta_energy)).cast(dtype).alias(col))
 
             # Update meters dataframe
             self.meters = self.meters.filter(self.meters[c.TC_TIMESTAMP] != self.timestamp + self.dt)

--- a/hamlet/executor/utilities/controller/rtc/rtc.py
+++ b/hamlet/executor/utilities/controller/rtc/rtc.py
@@ -484,7 +484,7 @@ class Rtc(ControllerBase):
                 # Extract power from variable values
                 key = next((key for key in solution if key.startswith(col) and key.endswith(energy_endings)), None)
 
-                if key:  # Check for matching keys
+                if key:  # Check for matching key
                     # Calculate energy from power
                     delta_energy = solution[key] * self.dt.total_seconds() * c.SECONDS_TO_HOURS
 


### PR DESCRIPTION
## TL;DR
Previously meters recorded by ID which caused issues when component had more than one energy type, e.g. heat pump. Meter column names are considering this now so that the meters record all energy types per component

---

## Linked Issues
Closes #84 

## Description
See TLDR.

## How to test
Run example file (create scenario if necessary)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My PR is concise and addresses only one bug/feature (otherwise split PR into two)
- [x] My PR has a concise and descriptive title
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code and PR and have added comments in the PR code to help the reviewer.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Additional Notes
Add any other notes or comments here.

[How to make a good PR (Video)](https://www.youtube.com/watch?v=_HedItVFr5M)
